### PR TITLE
disable download button when habit list is empty

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -98,7 +98,10 @@ const App = () => {
         <div className="ui one column stackable center aligned page grid">
           <div className="column twelve wide">
             <div className="download-button">
-              <DownloadButton refRenderRoot={refRenderRoot} />
+              <DownloadButton 
+                disabled={habits.length < 1} 
+                refRenderRoot={refRenderRoot} 
+              />
             </div>
           </div>
         </div>

--- a/src/components/DownloadButton.js
+++ b/src/components/DownloadButton.js
@@ -22,7 +22,7 @@ const range = (start, end) => {
 // TODO(shyam):
 // - this is likely broken for > 4 months worth of tables (need to support multiple pages)
 // - this is likely broken for different screen resolutions or browser size configurations.. needs more testing.
-const DownloadButton = ({ refRenderRoot }) => {
+const DownloadButton = ({ refRenderRoot, disabled }) => {
   const [loading, setLoading] = useState(false);
 
   const onClickDownload = () => {
@@ -90,6 +90,7 @@ const DownloadButton = ({ refRenderRoot }) => {
       <button
         onClick={() => onClickDownload()}
         className={"ui primary button " + (loading ? "loading" : "")}
+        disabled={disabled}
       >
         Download Template as PDF
       </button>


### PR DESCRIPTION
Solving this issue : #6 
Everything seems to work as intended.

I had to run `npm audit fix --force` to be able to start the application, because the package manager complained about high severity issues and the app wouldn't start. I didn't include changes made to `package.json` since this is not related to the issue this PR is trying to solve.